### PR TITLE
Updates Ingress Template

### DIFF
--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -1,7 +1,14 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "superset.fullname" . -}}
 {{- $ingressPath := .Values.ingress.path -}}
+{{- $svcPort := 8088 -}}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -15,6 +22,9 @@ metadata:
     {{- . | toYaml | nindent 4 }}
   {{- end }}
 spec:
+  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
   {{- if .Values.ingress.tls }}
   tls:
     {{- range .Values.ingress.tls }}
@@ -34,10 +44,15 @@ spec:
           - path: {{ . }}
             pathType: Prefix
             backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
               service:
                 name: {{ $fullName }}
                 port:
-                  number: 8088
+                  number: {{ $svcPort | default 8088 }}
+              {{- else }}
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort | default 8088 }}
+              {{- end }}
         {{- end }}
     {{- end }}
 {{- end }}

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -2,6 +2,11 @@
 {{- $fullName := include "superset.fullname" . -}}
 {{- $ingressPath := .Values.ingress.path -}}
 {{- $svcPort := 8088 -}}
+{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
+  {{- end }}
+{{- end }}
 {{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1
 {{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}


### PR DESCRIPTION
Compatibility for multiple k8s versions
- Supports mulitple api versions: 
        - `networking.k8s.io/v1` for k8s version 1.19+ 
        -  `networking.k8s.io/v1beta1` for k8s version 1.14 - <1.18
        -  `extensions/v1beta1` for k8s version <1.14 
- Support `ingressClassName` for k8s 1.18+ and `kubernetes.io/ingress.class` annotation for previous versions
- Support backend ingress syntax for k8s version 1.19+ and previous versions
