### PR TITLE
19274: The PUBLIC_ROLE_LIKE_GAMMA config key has been removed

### DIFF
--- a/test/examples/whitelabel/config.py
+++ b/test/examples/whitelabel/config.py
@@ -97,7 +97,7 @@ AUTH_USER_REGISTRATION_ROLE = 'Public'
 # Will allow user self registration
 AUTH_USER_REGISTRATION = True
 # Set public role like Gamma
-PUBLIC_ROLE_LIKE_GAMMA = True
+PUBLIC_ROLE_LIKE = "Gamma"
 
 # ---------------------------------------------------
 # Image and file configuration


### PR DESCRIPTION
Set PUBLIC_ROLE_LIKE = "Gamma" to have the same functionality.

https://github.com/apache/superset/pull/19274